### PR TITLE
feat!: `@openng` rename

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "always"
   },
-  "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": "always"
-    },
+    "source.fixAll.eslint": "always"
+  },
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) Scott Cooper <scttcper@gmail.com>
+Copyright (c) 2026 OpenNG
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) Scott Cooper <scttcper@gmail.com>
-Copyright (c) 2026 OpenNG
+Copyright (c) OpenNG contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm install @openng/ngx-toastr --save
 **step 1:** add css
 
 - copy
-  [toast css](projects/ngx-toastr/src/lib/toastr.css)
+  [toast css](https://github.com/openng-org/ngx-toastr/blob/master/projects/ngx-toastr/src/lib/toastr.css)
   to your project.
 - If you are using sass you can import the css.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ DEMO: <https://ngx-toastr.vercel.app>
 - No use of `@angular/animations`
 - AoT compilation and lazy loading compatible
 - Component inheritance for custom toasts
-- SystemJS/UMD rollup bundle
 - Output toasts to an optional target directive
 
 ## Dependencies
@@ -50,7 +49,7 @@ npm install @openng/ngx-toastr --save
 **step 1:** add css
 
 - copy
-  [toast css](/projects/ngx-toastr/src/lib/toastr.css)
+  [toast css](projects/ngx-toastr/src/lib/toastr.css)
   to your project.
 - If you are using sass you can import the css.
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 <div align="center">
-  <img src="https://raw.githubusercontent.com/scttcper/ngx-toastr/master/misc/documentation-assets/ngx-toastr-example.png" width="300" alt="Angular Toastr">
+  <img src="https://raw.githubusercontent.com/openng-org/ngx-toastr/master/misc/documentation-assets/ngx-toastr-example.png" width="300" alt="Angular Toastr">
   <br>
-  <h1>ngx-toastr</h1>
+  <h1>@openng/ngx-toastr</h1>
   <br>
-  <a href="https://www.npmjs.org/package/ngx-toastr">
-    <img src="https://badge.fury.io/js/ngx-toastr.svg" alt="npm">
+  <a href="https://www.npmjs.com/package/@openng/ngx-toastr">
+    <img src="https://badge.fury.io/js/%40openng%2Fngx-toastr.svg" alt="npm">
   </a>
-  <a href="https://codecov.io/github/scttcper/ngx-toastr">
-    <img src="https://img.shields.io/codecov/c/github/scttcper/ngx-toastr.svg" alt="codecov">
+  <a href="https://codecov.io/github/openng-org/ngx-toastr">
+    <img src="https://img.shields.io/codecov/c/github/openng-org/ngx-toastr.svg" alt="codecov">
   </a>
   <br>
   <br>
 </div>
 
-DEMO: https://ngx-toastr.vercel.app
+DEMO: <https://ngx-toastr.vercel.app>
+
+> [!NOTE]
+> `@openng/ngx-toastr` is an OpenNG-maintained fork of the original
+> [`ngx-toastr`](https://github.com/scttcper/ngx-toastr) project.
 
 ## Features
 
@@ -27,22 +31,18 @@ DEMO: https://ngx-toastr.vercel.app
 
 ## Dependencies
 
-Latest version available for each version of Angular
+Latest version available for each version of Angular:
 
-| ngx-toastr      | Angular         |
-| --------------- | --------------- |
-| 13.2.1          | 10.x 11.x       |
-| 14.3.0          | 12.x 13.x       |
-| 15.2.2          | 14.x.           |
-| 16.2.0          | 15.x            |
-| 17.0.2          | 16.x            |
-| 18.x 19x        | >= 17.x < 23.x  |
-| current         | >= 20.x         |
+| `@openng/ngx-toastr` | Angular |
+|----------------------|---------|
+| 1.x                  | 21.x    |
+
+(For older versions, see the original `ngx-toastr`.)
 
 ## Install
 
 ```bash
-npm install ngx-toastr --save
+npm install @openng/ngx-toastr --save
 ```
 
 ## Setup
@@ -50,27 +50,27 @@ npm install ngx-toastr --save
 **step 1:** add css
 
 - copy
-  [toast css](/src/lib/toastr.css)
+  [toast css](/projects/ngx-toastr/src/lib/toastr.css)
   to your project.
 - If you are using sass you can import the css.
 
 ```scss
 // regular style toast
-@import 'ngx-toastr/toastr';
+@import '@openng/ngx-toastr/toastr';
 
 // bootstrap style toast
 // or import a bootstrap 4 alert styled design (SASS ONLY)
 // should be after your bootstrap imports, it uses bs4 variables, mixins, functions
-@import 'ngx-toastr/toastr-bs4-alert';
+@import '@openng/ngx-toastr/toastr-bs4-alert';
 
 // if you'd like to use it without importing all of bootstrap it requires
 @import 'bootstrap/scss/functions';
 @import 'bootstrap/scss/variables';
 @import 'bootstrap/scss/mixins';
 // bootstrap 4
-@import 'ngx-toastr/toastr-bs4-alert';
+@import '@openng/ngx-toastr/toastr-bs4-alert';
 // boostrap 5
-@import 'ngx-toastr/toastr-bs5-alert';
+@import '@openng/ngx-toastr/toastr-bs5-alert';
 ```
 
 - If you are using angular-cli you can add it to your angular.json
@@ -78,7 +78,7 @@ npm install ngx-toastr --save
 ```ts
 "styles": [
   "styles.scss",
-  "node_modules/ngx-toastr/toastr.css" // try adding '../' if you're using angular cli before 6
+  "node_modules/@openng/ngx-toastr/toastr.css"
 ]
 ```
 
@@ -87,7 +87,7 @@ npm install ngx-toastr --save
 - Module based
 
 ```typescript
-import { ToastrModule } from 'ngx-toastr';
+import { ToastrModule } from '@openng/ngx-toastr';
 
 @NgModule({
   imports: [
@@ -103,7 +103,7 @@ class MainModule {}
 
 ```typescript
 import { AppComponent } from './src/app.component';
-import { provideToastr } from 'ngx-toastr';
+import { provideToastr } from '@openng/ngx-toastr';
 
 bootstrapApplication(AppComponent, {
   providers: [
@@ -115,7 +115,7 @@ bootstrapApplication(AppComponent, {
 ## Use
 
 ```typescript
-import { ToastrService } from 'ngx-toastr';
+import { ToastrService } from '@openng/ngx-toastr';
 import { inject } from '@angular/core';
 
 @Component({...})
@@ -136,7 +136,7 @@ There are **individual options** and **global options**.
 
 Passed to `ToastrService.success/error/warning/info/show()`
 
-| Option            | Type                           | Default                        | Description                                                                             
+| Option            | Type                           | Default                        | Description                                       |
 | ----------------- | ------------------------------ | ------------------------------ | ------------------------------------------------- |
 | toastComponent    | Component                      | Toast                          | Angular component that will be used               |
 | closeButton       | boolean                        | false                          | Show close button                                 |
@@ -173,7 +173,7 @@ All [individual options](#individual-options) can be overridden in the global
 options to affect all toasts. In addition, global options include the following
 options:
 
-| Option                  | Type    | Default                            | Description                                                                                                   |
+| Option                  | Type    | Default                            | Description                                                        |
 | ----------------------- | ------- | ---------------------------------- | ------------------------------------------------------------------ |
 | maxOpened               | number  | 0                                  | Max toasts opened. Toasts will be queued. 0 is unlimited           |
 | autoDismiss             | boolean | false                              | Dismiss current toast when max is reached                          |
@@ -215,7 +215,7 @@ imports: [
 
 ```typescript
 import { AppComponent } from './src/app.component';
-import { provideToastr } from 'ngx-toastr';
+import { provideToastr } from '@openng/ngx-toastr';
 
 bootstrapApplication(AppComponent, {
   providers: [
@@ -228,8 +228,7 @@ bootstrapApplication(AppComponent, {
 });
 ```
 
-
-### Toastr Service methods return:
+### Toastr Service methods return
 
 ```typescript
 export interface ActiveToast {
@@ -264,7 +263,7 @@ the container it is announced by screen readers.
 
 ```typescript
 import { NgModule } from '@angular/core';
-import { ToastrModule, ToastContainerDirective } from 'ngx-toastr';
+import { ToastrModule, ToastContainerDirective } from '@openng/ngx-toastr';
 import { AppComponent } from './app.component';
 
 @NgModule({
@@ -283,7 +282,7 @@ Add a div with `toastContainer` directive on it.
 
 ```typescript
 import { Component, OnInit, viewChild, inject } from '@angular/core';
-import { ToastContainerDirective, ToastrService } from 'ngx-toastr';
+import { ToastContainerDirective, ToastrService } from '@openng/ngx-toastr';
 
 @Component({
   selector: 'app-root',
@@ -319,34 +318,20 @@ toastrService.clear(toastId?: number);
 
 Remove and destroy a single toast by id
 
-```
+```ts
 toastrService.remove(toastId: number);
-```
-
-## SystemJS
-
-If you are using SystemJS, you should also adjust your configuration to point to
-the UMD bundle.
-
-In your SystemJS config file, `map` needs to tell the System loader where to
-look for `ngx-toastr`:
-
-```js
-map: {
-  'ngx-toastr': 'node_modules/ngx-toastr/bundles/ngx-toastr.umd.min.js',
-}
 ```
 
 ## Setup Without Animations
 
-If you do not want animations you can override the default 
+If you do not want animations you can override the default
 toast component in the global config to use
 `ToastNoAnimation` instead of the default one.
 
 In your main module (ex: `app.module.ts`)
 
 ```typescript
-import { ToastrModule, ToastNoAnimation, ToastNoAnimationModule } from 'ngx-toastr';
+import { ToastrModule, ToastNoAnimation, ToastNoAnimationModule } from '@openng/ngx-toastr';
 
 @NgModule({
   imports: [
@@ -363,10 +348,10 @@ That's it! No animations.
 ## Using A Custom Toast
 
 Create your toast component extending Toast see the demo's pink toast for an example
-https://github.com/scttcper/ngx-toastr/blob/master/src/app/pink.toast.ts
+<https://github.com/openng-org/ngx-toastr/blob/master/src/app/pink-toast/pink-toast.component.ts>
 
 ```typescript
-import { ToastrModule } from 'ngx-toastr';
+import { ToastrModule } from '@openng/ngx-toastr';
 
 @NgModule({
   imports: [
@@ -393,12 +378,13 @@ ngOnInit() {
 ```
 
 2.  Change default icons (check, warning sign, etc)\
-    Overwrite the css background-image: https://github.com/scttcper/ngx-toastr/blob/master/src/lib/toastr.css.
+    Overwrite the css background-image: <https://github.com/openng-org/ngx-toastr/blob/master/projects/ngx-toastr/src/lib/toastr.css>.
 3.  How do I use this in an ErrorHandler?\
-    See: https://github.com/scttcper/ngx-toastr/issues/179.
+    See: <https://github.com/scttcper/ngx-toastr/issues/179>.
 4.  How can I translate messages?\
-    See: https://github.com/scttcper/ngx-toastr/issues/201.
+    See: <https://github.com/scttcper/ngx-toastr/issues/201>.
 5.  How to handle toastr click/tap action?
+
     ```ts
     showToaster() {
       this.toastr.success('Hello world!', 'Toastr fun!')
@@ -411,12 +397,15 @@ ngOnInit() {
       console.log('Toastr clicked');
     }
     ```
+
 6. How to customize styling without overridding defaults?\
     Add multiple CSS classes separated by a space:
+
     ```ts
     toastClass: 'yourclass ngx-toastr'
     ```
-    See: https://github.com/scttcper/ngx-toastr/issues/594.
+
+    See: <https://github.com/scttcper/ngx-toastr/issues/594>.
 
 ## Previous Works
 
@@ -430,5 +419,7 @@ MIT
 
 ---
 
-> GitHub [@scttcper](https://github.com/scttcper) &nbsp;&middot;&nbsp;
-> Twitter [@scttcper](https://twitter.com/scttcper)
+Maintained by [OpenNG](https://www.openng.org/).
+
+Originally created by GitHub [@scttcper](https://github.com/scttcper) &nbsp;&middot;&nbsp;
+Twitter [@scttcper](https://twitter.com/scttcper)

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ngx-toastr-site",
       "version": "0.0.0",
+      "license": "MIT",
       "dependencies": {
         "@angular/common": "^21.1.0",
         "@angular/compiler": "^21.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "packageManager": "npm@11.7.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scttcper/ngx-toastr"
+    "url": "https://github.com/openng-org/ngx-toastr"
   },
   "license": "MIT",
   "dependencies": {

--- a/projects/ngx-toastr/package.json
+++ b/projects/ngx-toastr/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ngx-toastr",
-  "version": "0.0.1",
+  "name": "@openng/ngx-toastr",
+  "version": "0.0.0-development",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^21.0.0",
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/scttcper/ngx-toastr"
+    "url": "https://github.com/openng-org/ngx-toastr"
   },
   "exports": {
     "./toastr": {

--- a/projects/ngx-toastr/src/lib/toastr/toast.provider.ts
+++ b/projects/ngx-toastr/src/lib/toastr/toast.provider.ts
@@ -16,7 +16,7 @@ export const DefaultGlobalConfig: GlobalConfig = {
  *
  * @example
  * ```ts
- * import { provideToastr } from 'ngx-toastr';
+ * import { provideToastr } from '@openng/ngx-toastr';
  *
  * bootstrap(AppComponent, {
  *   providers: [

--- a/projects/ngx-toastr/src/public-api.ts
+++ b/projects/ngx-toastr/src/public-api.ts
@@ -1,5 +1,5 @@
 /*
- * Public API Surface of ngx-toastr
+ * Public API Surface of @openng/ngx-toastr
  */
 
 export * from './lib';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ToastNoAnimationModule } from 'ngx-toastr';
+import { ToastNoAnimationModule } from '@openng/ngx-toastr';
 import { FooterComponent } from './footer/footer.component';
 import { HeaderComponent } from './header/header.component';
 import { HomeComponent } from './home/home.component';

--- a/src/app/bootstrap-toast/bootstrap-toast.component.ts
+++ b/src/app/bootstrap-toast/bootstrap-toast.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Toast } from 'ngx-toastr';
+import { Toast } from '@openng/ngx-toastr';
 
 @Component({
   selector: '[bootstrap-toast-component]',

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -6,9 +6,9 @@ import { Component, VERSION } from '@angular/core';
     <footer class="footer mb-4 mt-5">
       Angular {{ version }}
       <br />
-      <a href="https://github.com/scttcper/ngx-toastr/blob/master/LICENSE">MIT license</a>
+      <a href="https://github.com/openng-org/ngx-toastr/blob/master/LICENSE">MIT license</a>
       -
-      <a href="https://github.com/scttcper/ngx-toastr">Source</a>
+      <a href="https://github.com/openng-org/ngx-toastr">Source</a>
     </footer>
   `,
   styles: [

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -5,9 +5,9 @@ import { GhButtonModule } from '@ctrl/ngx-github-buttons';
   selector: 'app-header',
   template: `
     <header class="header mt-5 text-center">
-      <h1>Angular Toastr</h1>
+      <h1>@openng/ngx-toastr</h1>
       <p style="color: #777" class="mb-1">Easy Toasts for Angular</p>
-      <gh-button user="scttcper" repo="ngx-toastr" [count]="true"></gh-button>
+      <gh-button user="openng-org" repo="ngx-toastr" [count]="true"></gh-button>
     </header>
   `,
   imports: [GhButtonModule],

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,5 +1,5 @@
 import { Component, VERSION, ChangeDetectionStrategy, inject, viewChildren } from '@angular/core';
-import { GlobalConfig, ToastrService, ToastContainerDirective } from 'ngx-toastr';
+import { GlobalConfig, ToastrService, ToastContainerDirective } from '@openng/ngx-toastr';
 import { FormsModule } from '@angular/forms';
 import { ToastManagerService } from '../toast-manager.service';
 

--- a/src/app/notyf-toast/notyf-toast.component.ts
+++ b/src/app/notyf-toast/notyf-toast.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Toast } from 'ngx-toastr';
+import { Toast } from '@openng/ngx-toastr';
 
 @Component({
   selector: 'notyf-toast-component',

--- a/src/app/pink-toast/pink-toast.component.ts
+++ b/src/app/pink-toast/pink-toast.component.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
-
-import { Toast } from 'ngx-toastr';
+import { Toast } from '@openng/ngx-toastr';
 
 @Component({
   selector: '[pink-toast-component]',

--- a/src/app/toast-manager.service.ts
+++ b/src/app/toast-manager.service.ts
@@ -6,7 +6,7 @@ import {
   type ActiveToast,
   type GlobalConfig,
   type IndividualConfig,
-} from 'ngx-toastr';
+} from '@openng/ngx-toastr';
 import { BootstrapToast } from './bootstrap-toast/bootstrap-toast.component';
 import { NotyfToast } from './notyf-toast/notyf-toast.component';
 import { PinkToast } from './pink-toast/pink-toast.component';

--- a/src/app/toasts.spec.ts
+++ b/src/app/toasts.spec.ts
@@ -1,5 +1,11 @@
 import { TestBed } from '@angular/core/testing';
-import { Toast, ActiveToast, ToastrModule, type ToastNoAnimation, ToastrService } from 'ngx-toastr';
+import {
+  Toast,
+  ActiveToast,
+  ToastrModule,
+  type ToastNoAnimation,
+  ToastrService,
+} from '@openng/ngx-toastr';
 import { NotyfToast } from './notyf-toast/notyf-toast.component';
 import { PinkToast } from './pink-toast/pink-toast.component';
 import { firstValueFrom } from 'rxjs';

--- a/src/index.html
+++ b/src/index.html
@@ -33,14 +33,14 @@
       content="https://raw.githubusercontent.com/openng-org/ngx-toastr/master/misc/documentation-assets/ngx-toastr-example.png"
     />
     <!-- Open Graph general (Facebook, Pinterest & Google+) -->
-    <meta name="og:title" content="@openng/ngx-toastr" />
+    <meta property="og:title" content="@openng/ngx-toastr" />
     <meta
-      name="og:image"
+      property="og:image"
       content="https://raw.githubusercontent.com/openng-org/ngx-toastr/master/misc/documentation-assets/ngx-toastr-example.png"
     />
-    <meta name="og:url" content="https://ngx-toastr.vercel.app/" />
-    <meta name="og:site_name" content="@openng/ngx-toastr" />
-    <meta name="og:type" content="website" />
+    <meta property="og:url" content="https://ngx-toastr.vercel.app/" />
+    <meta property="og:site_name" content="@openng/ngx-toastr" />
+    <meta property="og:type" content="website" />
   </head>
   <body>
     <app-root></app-root>

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Angular Toastr</title>
+    <title>@openng/ngx-toastr</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
@@ -12,56 +12,35 @@
       name="keywords"
       content="Angular2,ng2,toastr,angular,toast,notification,ngmodule,ngx-toastr"
     />
-    <meta name="author" content="@scttcper" />
+    <meta name="author" content="OpenNG" />
 
     <!-- Search Engine -->
     <meta
       name="image"
-      content="https://raw.githubusercontent.com/scttcper/ngx-toastr/master/misc/documentation-assets/ngx-toastr-example.png"
+      content="https://raw.githubusercontent.com/openng-org/ngx-toastr/master/misc/documentation-assets/ngx-toastr-example.png"
     />
     <!-- Schema.org for Google -->
-    <meta itemprop="name" content="Angular Toastr" />
+    <meta itemprop="name" content="@openng/ngx-toastr" />
     <meta
       itemprop="image"
-      content="https://raw.githubusercontent.com/scttcper/ngx-toastr/master/misc/documentation-assets/ngx-toastr-example.png"
+      content="https://raw.githubusercontent.com/openng-org/ngx-toastr/master/misc/documentation-assets/ngx-toastr-example.png"
     />
     <!-- Twitter -->
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="Angular Toastr" />
-    <meta name="twitter:site" content="@scttcper" />
-    <meta name="twitter:creator" content="@scttcper" />
+    <meta name="twitter:title" content="@openng/ngx-toastr" />
     <meta
       name="twitter:image:src"
-      content="https://raw.githubusercontent.com/scttcper/ngx-toastr/master/misc/documentation-assets/ngx-toastr-example.png"
+      content="https://raw.githubusercontent.com/openng-org/ngx-toastr/master/misc/documentation-assets/ngx-toastr-example.png"
     />
     <!-- Open Graph general (Facebook, Pinterest & Google+) -->
-    <meta name="og:title" content="Angular Toastr" />
+    <meta name="og:title" content="@openng/ngx-toastr" />
     <meta
       name="og:image"
-      content="https://raw.githubusercontent.com/scttcper/ngx-toastr/master/misc/documentation-assets/ngx-toastr-example.png"
+      content="https://raw.githubusercontent.com/openng-org/ngx-toastr/master/misc/documentation-assets/ngx-toastr-example.png"
     />
-    <meta name="og:url" content="https://ngx-toastr.netlify.com/" />
-    <meta name="og:site_name" content="Angular Toastr" />
+    <meta name="og:url" content="https://ngx-toastr.vercel.app/" />
+    <meta name="og:site_name" content="@openng/ngx-toastr" />
     <meta name="og:type" content="website" />
-
-    <script>
-      (function (i, s, o, g, r, a, m) {
-        i['GoogleAnalyticsObject'] = r;
-        ((i[r] =
-          i[r] ||
-          function () {
-            (i[r].q = i[r].q || []).push(arguments);
-          }),
-          (i[r].l = 1 * new Date()));
-        ((a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]));
-        a.async = 1;
-        a.src = g;
-        m.parentNode.insertBefore(a, m);
-      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-
-      ga('create', 'UA-84656736-1', 'auto');
-      ga('send', 'pageview');
-    </script>
   </head>
   <body>
     <app-root></app-root>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { AppComponent } from './app/app.component';
 import { provideBrowserGlobalErrorListeners } from '@angular/core';
-import { provideToastr } from 'ngx-toastr';
+import { provideToastr } from '@openng/ngx-toastr';
 
 bootstrapApplication(AppComponent, {
   providers: [provideBrowserGlobalErrorListeners(), provideToastr()],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "module": "preserve",
     "moduleResolution": "bundler",
     "paths": {
-      "ngx-toastr": [
+      "@openng/ngx-toastr": [
         "./projects/ngx-toastr/src/public-api.ts"
       ]
     },


### PR DESCRIPTION
## Description

The package has been renamed to with the `@openng` namespace.  Documentation has been updated.  References to SystemJS have been removed.  OpenNG has been added to LICENSE.  Open Graph metadata has been fixed (needs to use `property`).

## Related issues

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

Import path is now `@openng/ngx-toastr` instead of `ngx-toastr`.

## Test plan


- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`
- [x] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [x] Tests added or updated for behavioral changes
- [x] Documentation updated (README, JSDoc, migration notes as needed)
- [x] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

This is not everything for release.  Out of scope for this PR:

- Get the release workflow working, trusted publishing, versioning, etc.
- Migrate the demo app to GitHub Pages.
