### PR TITLE
chore: use release-please

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write # for trusted publishing
+      id-token: write # for OIDC
+      pull-requests: write # for labelling PRs
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -40,3 +41,52 @@ jobs:
         run: |
           npm publish --access public --provenance
         working-directory: dist/ngx-toastr
+
+      - name: Update Release PR Label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            // Find the PR.
+            const { owner, repo } = context.repo;
+            const commit_sha = context.payload.release.target_commitish;
+            const { data: pullRequests } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner,
+              repo,
+              commit_sha,
+            });
+            if (pullRequests.length === 0) {
+              core.info(`No pull request found for '${commit_sha}'.`);
+              return;
+            }
+            const releasePullRequests = pullRequests.filter(pullRequest =>
+              pullRequest.merged_at &&
+              pullRequest.base.ref === context.payload.repository.default_branch &&
+              pullRequest.head.ref.startsWith('release-please--branches--')
+            );
+            if (releasePullRequests.length !== 1) {
+              throw new Error(`Expected one release pull request for '${commit_sha}', found ${releasePullRequests.length}.`);
+            }
+
+            // Swap labels.
+            const issue_number = releasePullRequests[0].number;
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number,
+              labels: ['autorelease: published'],
+            });
+            await github.rest.issues.removeLabel({
+              owner,
+              repo,
+              issue_number,
+              name: 'autorelease: tagged',
+            });
+
+            // Comment on PR.
+            const releaseTag = context.payload.release.tag_name;
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: `🚀 Release \`${releaseTag}\` has been published!`,
+            });

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,5 +38,5 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # temporary only for first publish
         run: |
-          npm publish --access public
+          npm publish --access public --provenance
         working-directory: dist/ngx-toastr

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,76 @@
+name: Publish
+
+on:
+  release:
+    types:
+      - published
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # for trusted publishing
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false # no cache poisoning please
+          check-latest: true
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Validate release artifact
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { readFileSync } = require('node:fs');
+            const { join } = require('node:path');
+
+            const tag = context.payload.release.tag_name;
+            if (!/^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/.test(tag)) {
+              core.setFailed(`Invalid release tag: ${tag}`);
+              return;
+            }
+
+            const version = tag.slice(1);
+            const packageVersion = (path) => JSON.parse(readFileSync(join(process.env.GITHUB_WORKSPACE, path))).version;
+            const sourceVersion = packageVersion('projects/ngx-toastr/package.json');
+            const artifactVersion = packageVersion('dist/ngx-toastr/package.json');
+            if (sourceVersion !== version || artifactVersion !== version) {
+              core.setFailed(`Release ${version} does not match source ${sourceVersion} and artifact ${artifactVersion}`);
+            }
+
+      - name: Publish with Provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # temporary only for first publish
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version="${TAG#v}"
+          if npm view "@openng/ngx-toastr@$version" version > /dev/null 2>&1; then
+            echo "@openng/ngx-toastr@$version is already published"
+            exit 0
+          fi
+
+          npm_tag=latest
+          if [[ "$version" == *-* ]]; then
+            npm_tag="${version#*-}"
+            npm_tag="${npm_tag%%.*}"
+          fi
+
+          npm publish --access public --tag "$npm_tag"
+        working-directory: dist/ngx-toastr

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,43 +34,9 @@ jobs:
       - run: npm ci
       - run: npm run build
 
-      - name: Validate release artifact
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            const { readFileSync } = require('node:fs');
-            const { join } = require('node:path');
-
-            const tag = context.payload.release.tag_name;
-            if (!/^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/.test(tag)) {
-              core.setFailed(`Invalid release tag: ${tag}`);
-              return;
-            }
-
-            const version = tag.slice(1);
-            const packageVersion = (path) => JSON.parse(readFileSync(join(process.env.GITHUB_WORKSPACE, path))).version;
-            const sourceVersion = packageVersion('projects/ngx-toastr/package.json');
-            const artifactVersion = packageVersion('dist/ngx-toastr/package.json');
-            if (sourceVersion !== version || artifactVersion !== version) {
-              core.setFailed(`Release ${version} does not match source ${sourceVersion} and artifact ${artifactVersion}`);
-            }
-
       - name: Publish with Provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # temporary only for first publish
-          TAG: ${{ github.event.release.tag_name }}
         run: |
-          version="${TAG#v}"
-          if npm view "@openng/ngx-toastr@$version" version > /dev/null 2>&1; then
-            echo "@openng/ngx-toastr@$version is already published"
-            exit 0
-          fi
-
-          npm_tag=latest
-          if [[ "$version" == *-* ]]; then
-            npm_tag="${version#*-}"
-            npm_tag="${npm_tag%%.*}"
-          fi
-
-          npm publish --access public --tag "$npm_tag"
+          npm publish --access public
         working-directory: dist/ngx-toastr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,37 +1,33 @@
-name: Release
-on:
-  workflow_run:
-    workflows: ['CI']
-    branches: [main]
-    types: [completed]
+name: Release Please
 
-permissions:
-  contents: read # for checkout
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+
+permissions: {}
 
 jobs:
-  release:
-    name: NPM Release
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+  release-please:
+    name: Release Please
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # to be able to publish a GitHub release
-      issues: write # to be able to comment on released issues
-      pull-requests: write # to be able to comment on released pull requests
-      id-token: write # to enable use of OIDC for trusted publishing and npm provenance
     steps:
-      # https://github.com/actions/checkout
-      - uses: actions/checkout@v6
-      # https://github.com/actions/setup-node
-      - uses: actions/setup-node@v6
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          node-version: 24
-          cache: 'npm'
-      # Ensure npm 11.5.1 or later is installed
-      - name: Update npm
-        run: npm install -g npm@latest
-      - run: npm ci
-      - run: npm run build
-      - name: Release
-        run: cd dist/ngx-toastr && npx semantic-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          client-id: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
+      - name: Create or update release
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "projects/ngx-toastr": "0.0.0"
+}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,12 +24,6 @@ Release Please derives the next version from commits that change `projects/ngx-t
 For squash merges, make the pull request title a Conventional Commit.
 Add a `BREAKING CHANGE:` footer when a breaking change needs more detail.
 
-## Recovery
-
-Rerun a failed Publish workflow after correcting its configuration.
-The workflow exits successfully if that version is already on npm.
-Never reuse a published npm version; merge a fix and release a new patch instead.
-
 ## Initial Setup
 
 ### GitHub App

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,58 @@
+# Releasing
+
+This project uses **Release Please**.
+
+## Release flow
+
+1. Merge changes into `main` using Conventional Commit titles.
+2. Release Please creates or updates a release pull request.
+3. Review the proposed version and changelog, wait for CI, and merge the pull request.
+4. Release Please creates a `vX.Y.Z` tag and GitHub release.
+5. The Publish workflow publishes `@openng/ngx-toastr` to npm.
+
+## Versioning
+
+Release Please derives the next version from commits that change `projects/ngx-toastr`:
+
+| Commit title                                | Version change |
+| ------------------------------------------- | -------------- |
+| `fix: correct timeout handling`             | Patch          |
+| `feat: add a toast option`                  | Minor          |
+| `feat!: change the public API`              | Major          |
+| `docs:`, `test:`, `build:`, `ci:`, `chore:` | None           |
+
+For squash merges, make the pull request title a Conventional Commit.
+Add a `BREAKING CHANGE:` footer when a breaking change needs more detail.
+
+## Recovery
+
+Rerun a failed Publish workflow after correcting its configuration.
+The workflow exits successfully if that version is already on npm.
+Never reuse a published npm version; merge a fix and release a new patch instead.
+
+## Initial Setup
+
+### GitHub App
+
+Release Please uses a GitHub App so its pull requests run CI and its releases start the Publish workflow.
+
+1. Create and install a GitHub App for this repository.
+2. Give the app read and write access to Contents, Issues, and Pull requests.
+3. Add the app client ID as the repository variable `RELEASE_PLEASE_APP_CLIENT_ID`.
+4. Generate a private key and add it as the repository secret `RELEASE_PLEASE_APP_PRIVATE_KEY`.
+
+### First npm release
+
+The package must exist on npm before trusted publishing can be configured.
+Use a token once to publish the first version:
+
+1. Create an npm access token that can publish packages in the `@openng` scope.
+2. Add the token as the repository secret `NPM_TOKEN`.
+3. Merge the first Release Please pull request.
+4. Confirm that `@openng/ngx-toastr` was published.
+5. In the npm package settings, add a GitHub Actions trusted publisher for repository `openng-org/ngx-toastr` and workflow `publish.yml`.
+6. Allow `npm publish`, then delete the `NPM_TOKEN` repository secret.
+7. Require two-factor authentication and disallow token-based publishing in the npm package settings.
+
+Later releases use npm's short-lived OIDC credentials.
+When `NPM_TOKEN` is absent, npm uses OIDC.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,7 @@ This project uses **Release Please**.
 1. Merge changes into `main` using Conventional Commit titles.
 2. Release Please creates or updates a release pull request.
 3. Review the proposed version and changelog, wait for CI, and merge the pull request.
-4. Release Please creates a `vX.Y.Z` tag and GitHub release.
+4. Release Please creates a `X.Y.Z` tag and GitHub release.
 5. The Publish workflow publishes `@openng/ngx-toastr` to npm.
 
 ## Versioning

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -55,4 +55,4 @@ Use a token once to publish the first version:
 7. Require two-factor authentication and disallow token-based publishing in the npm package settings.
 
 Later releases use npm's short-lived OIDC credentials.
-When `NPM_TOKEN` is absent, npm uses OIDC.
+The token, `--access public`, and `--provenance` may be removed from `publish.yml`.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "346ab91405fc82fb64b3a22d0a0f3523b2ff2dae",
+  "packages": {
+    "projects/ngx-toastr": {
+      "release-type": "node",
+      "changelog-path": "/CHANGELOG.md",
+      "include-component-in-tag": false,
+      "include-v-in-tag": true
+    }
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
       "release-type": "node",
       "changelog-path": "/CHANGELOG.md",
       "include-component-in-tag": false,
-      "include-v-in-tag": true
+      "include-v-in-tag": false
     }
   }
 }


### PR DESCRIPTION
Use release-please for releasing & publishing.  It cuts down on the manual/non-standard scripts we'd need to maintain.

This does require one-time setup for the repository.   Please follow "Initial Setup" in the RELEASE.md .