### PR TITLE
fix: duplicate toast counting with change detection

### DIFF
--- a/projects/ngx-toastr/src/lib/toastr/base-toast/base-toast.component.ts
+++ b/projects/ngx-toastr/src/lib/toastr/base-toast/base-toast.component.ts
@@ -1,6 +1,7 @@
 import {
   ApplicationRef,
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   computed,
   inject,
@@ -31,7 +32,9 @@ export class ToastBase<ConfigPayload = unknown> implements OnDestroy {
   protected toastrService = inject(ToastrService);
   protected appRef = inject(ApplicationRef);
   protected timeoutsService = inject(TimeoutsService);
+  private readonly cdr = inject(ChangeDetectorRef);
 
+  /** @deprecated This will become a signal the next major release. */
   duplicatesCount!: number;
   protected hideTime!: number;
 
@@ -70,6 +73,7 @@ export class ToastBase<ConfigPayload = unknown> implements OnDestroy {
       .countDuplicate()
       .subscribe(count => {
         this.duplicatesCount = count;
+        this.cdr.markForCheck();
       });
   }
 

--- a/src/app/toasts.spec.ts
+++ b/src/app/toasts.spec.ts
@@ -125,6 +125,31 @@ describe('Toasts', () => {
     expect(opened.toastRef.componentInstance).toBeDefined();
   });
 
+  it('should prevent and count duplicates', () => {
+    toastrService.toastrConfig.preventDuplicates = true;
+    toastrService.toastrConfig.countDuplicates = true;
+
+    const quote = { title: 'Duplicate title', message: 'Duplicate message' };
+    const opened1 = toastManager.openToastNoAnimation(
+      undefined,
+      undefined,
+      quote,
+    ) as ActiveToast<ToastNoAnimation>;
+    const opened2 = toastManager.openToastNoAnimation(undefined, undefined, quote);
+
+    expect(opened2).toBe(opened1);
+    expect(opened1.portal.instance.duplicatesCount).toBe(1);
+
+    const opened3 = toastManager.openToastNoAnimation(undefined, undefined, quote);
+
+    expect(opened3).toBe(opened1);
+    expect(opened1.portal.instance.duplicatesCount).toBe(2);
+    expect(toastrService.currentlyActive).toBe(1);
+
+    toastrService.toastrConfig.preventDuplicates = false;
+    toastrService.toastrConfig.countDuplicates = false;
+  });
+
   it('should close all toasts', () => {
     vi.useFakeTimers();
 


### PR DESCRIPTION
## Description

`duplicatesCount` needs to trigger change detection when it changes.

It would be better to make it a signal, but that's a breaking change to the public API; we'll come back to that in a future major release.

## Related issues

Fixes #25 and scttcper/ngx-toastr#1036

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking changes

None

## Test plan

- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`
- [x] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [x] Tests added or updated for behavioral changes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

<!-- Screenshots, StackBlitz links, SSR/zoneless notes, or anything else reviewers should know. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Duplicate toast notifications now reliably update their displayed count when repeated messages are consolidated.
  - Only one active toast remains for identical repeated notifications when duplicate handling is enabled.

- **Tests**
  - Added coverage verifying duplicate prevention, count increments, and preservation of a single active toast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->