### PR TITLE
chore: run demo app and tests as zoneless

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Passed to `ToastrService.success/error/warning/info/show()`
 | titleClass        | string                         | 'toast-title'                  | CSS class(es) for inside toast on title           |
 | messageClass      | string                         | 'toast-message'                | CSS class(es) for inside toast on message         |
 | tapToDismiss      | boolean                        | true                           | Close on click                                    |
-| onActivateTick    | boolean                        | false                          | Fires `changeDetectorRef.detectChanges()` when activated. Helps show toast from asynchronous events outside of Angular's change detection |
+| onActivateTick    | boolean                        | false                          | Runs toast creation inside `NgZone.run()`. Helps show toast from asynchronous events outside of Angular's change detection. Has no effect in zoneless applications. |
 
 #### Setting Individual Options
 

--- a/angular.json
+++ b/angular.json
@@ -32,7 +32,6 @@
             "browser": "src/main.ts",
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
-            "polyfills": ["zone.js"],
             "assets": [
               {
                 "glob": "**/*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,7 @@
         "bootstrap": "^5.3.8",
         "lodash-es": "^4.17.22",
         "rxjs": "~7.8.2",
-        "tslib": "^2.8.1",
-        "zone.js": "~0.15.1"
+        "tslib": "^2.8.1"
       },
       "devDependencies": {
         "@angular/build": "^20.3.0",
@@ -12783,12 +12782,6 @@
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }
-    },
-    "node_modules/zone.js": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
-      "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "bootstrap": "^5.3.8",
     "lodash-es": "^4.17.22",
     "rxjs": "~7.8.2",
-    "tslib": "^2.8.1",
-    "zone.js": "~0.15.1"
+    "tslib": "^2.8.1"
   },
   "devDependencies": {
     "@angular/build": "^20.3.0",

--- a/src/app/toasts.spec.ts
+++ b/src/app/toasts.spec.ts
@@ -1,3 +1,4 @@
+import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
   Toast,
@@ -26,7 +27,7 @@ describe('Toasts', () => {
           enableHtml: true,
         }),
       ],
-      providers: [ToastManagerService, ToastrService],
+      providers: [provideZonelessChangeDetection(), ToastManagerService, ToastrService],
     });
 
     toastManager = TestBed.inject(ToastManagerService);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,12 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { AppComponent } from './app/app.component';
-import { provideBrowserGlobalErrorListeners } from '@angular/core';
+import { provideBrowserGlobalErrorListeners, provideZonelessChangeDetection } from '@angular/core';
 import { provideToastr } from '@openng/ngx-toastr';
 
 bootstrapApplication(AppComponent, {
-  providers: [provideBrowserGlobalErrorListeners(), provideToastr()],
+  providers: [
+    provideZonelessChangeDetection(),
+    provideBrowserGlobalErrorListeners(),
+    provideToastr(),
+  ],
 }).catch(err => console.error(err));


### PR DESCRIPTION
We must build using the lowest supported Angular version, which is currently Angular 20.  v20 defaults to needing zone.js, so when we expanded the range to include v20, we re-added zone.js; this isn't necessary, since v20 supports opt-in zoneless. So this PR re-removes zone.js and adds the v20-only code to opt in.  The zoneless providers can be removed when we drop v20 support.

Also updated the docs for `onActivateTick` which is essentially a no-op in zoneless applications now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the application to use zoneless change detection for improved compatibility with modern Angular applications.
  * Toast behavior now clearly reflects that activation-triggered toast creation has no effect in zoneless applications.

* **Documentation**
  * Clarified the `onActivateTick` option documentation and its behavior when zoneless change detection is enabled.

* **Chores**
  * Removed the application’s dependency on Zone.js.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->